### PR TITLE
Fix failure on certbot renew and overly verbose cron

### DIFF
--- a/scripts/certbot-renew-crontab.sh
+++ b/scripts/certbot-renew-crontab.sh
@@ -5,7 +5,7 @@ CERTIFICATE="/etc/letsencrypt/live/$POSTFIX_FQDN/fullchain.pem"
 PRIVATE_KEY="/etc/letsencrypt/live/$POSTFIX_FQDN/privkey.pem"
 
 if [ -f $CERTIFICATE -a -f $PRIVATE_KEY ]; then
-    certbot -n renew
+    certbot -q renew
 else
-    certbot -n certonly
+    certbot -q certonly
 fi

--- a/templates/certbot/cli.ini
+++ b/templates/certbot/cli.ini
@@ -1,4 +1,4 @@
-domain = {{ env['POSTFIX_FQDN'] }}
+domains = {{ env['POSTFIX_FQDN'] }}
 email = {{ env['LETSENCRYPT_EMAIL'] }}
 
 authenticator = standalone


### PR DESCRIPTION
Fix for #6 where certbot renew is not able to use cli.ini because it contains shortened parameter name `domain` instead of `domains`.

Changed verbosity from -n to -q to stop cron from generating emails every hour.